### PR TITLE
[Feat/#17] 하단 메뉴 공통 컴포넌트 구현

### DIFF
--- a/components/common/BottomMenu.tsx
+++ b/components/common/BottomMenu.tsx
@@ -5,7 +5,7 @@ import Typo from './Typo';
 import { styles } from 'navigation/BottomNavigator';
 
 interface BottomMenuProps {
-  menuItems: { label: string; action: () => void }[];
+  menuItems: { label: string; action: <T extends unknown[]>(...args: T) => void }[];
   onlyCancel?: boolean;
 }
 

--- a/components/common/BottomMenu.tsx
+++ b/components/common/BottomMenu.tsx
@@ -13,23 +13,16 @@ const BottomMenu = ({ menuItems, onlyCancel = false }: BottomMenuProps) => {
   const navigation = useNavigation();
 
   useEffect(() => {
-    navigation.setOptions({
-      tabBarStyle: { display: 'none' },
-    });
-
-    return () => {
-      navigation.setOptions({
-        tabBarStyle: styles.tabBar,
-      });
-    };
+    navigation.setOptions({ tabBarStyle: { display: 'none' } });
+    return () => navigation.setOptions({ tabBarStyle: styles.tabBar });
   }, [navigation]);
 
   return (
     <View className="absolute bottom-0 flex flex-row w-full h-[82] bg-secondaryBg border-t border-b border-black">
       {menuItems.map(({ label, action }, index) => {
+        const isLastItem = index === menuItems.length - 1;
         const isCancel = label === '취소';
         const isDelete = label === '삭제';
-        const isLastItem = index === menuItems.length - 1;
 
         return (
           <TouchableOpacity
@@ -41,7 +34,13 @@ const BottomMenu = ({ menuItems, onlyCancel = false }: BottomMenuProps) => {
           >
             <Typo
               variant="text-16_SB"
-              className={isDelete || onlyCancel ? 'text-red-500' : 'text-black'}
+              className={
+                isDelete || onlyCancel
+                  ? 'text-brand'
+                  : isCancel
+                    ? 'text-grey'
+                    : 'text-black'
+              }
             >
               {label}
             </Typo>

--- a/components/common/BottomMenu.tsx
+++ b/components/common/BottomMenu.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect } from 'react';
+import { View, TouchableOpacity } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import Typo from './Typo';
+import { styles } from 'navigation/BottomNavigator';
+
+interface BottomMenuProps {
+  menuItems: { label: string; action: () => void }[];
+  onlyCancel?: boolean;
+}
+
+const BottomMenu = ({ menuItems, onlyCancel = false }: BottomMenuProps) => {
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    navigation.setOptions({
+      tabBarStyle: { display: 'none' },
+    });
+
+    return () => {
+      navigation.setOptions({
+        tabBarStyle: styles.tabBar,
+      });
+    };
+  }, [navigation]);
+
+  return (
+    <View className="absolute bottom-0 flex flex-row w-full h-[82] bg-secondaryBg border-t border-b border-black">
+      {menuItems.map(({ label, action }, index) => {
+        const isCancel = label === '취소';
+        const isDelete = label === '삭제';
+        const isLastItem = index === menuItems.length - 1;
+
+        return (
+          <TouchableOpacity
+            key={label}
+            className={`flex-1 items-center py-[18]
+              ${isLastItem || 'border-r border-black'}
+              ${(isCancel || isDelete) && 'bg-primaryBg'}`}
+            onPress={action}
+          >
+            <Typo
+              variant="text-16_SB"
+              className={isDelete || onlyCancel ? 'text-red-500' : 'text-black'}
+            >
+              {label}
+            </Typo>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+};
+
+export default BottomMenu;

--- a/components/common/index.ts
+++ b/components/common/index.ts
@@ -1,5 +1,6 @@
+import BottomMenu from './BottomMenu';
 import Header from './Header';
 import LNB from './LNB';
 import Typo from './Typo';
 
-export { Header, LNB, Typo };
+export { BottomMenu, Header, LNB, Typo };

--- a/navigation/BottomNavigator.tsx
+++ b/navigation/BottomNavigator.tsx
@@ -50,7 +50,7 @@ const BottomNavigator = () => {
   );
 };
 
-const styles = StyleSheet.create({
+export const styles = StyleSheet.create({
   tabBar: {
     backgroundColor: colors.secondaryBg,
     borderTopWidth: 1,


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#이슈번호] 기능 추가 및 변경" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #17


## 🗝️ Key Changes
<!-- 작업 내용에 대한 설명/이슈사항을 작성해주세요. -->
### 1. 하단 메뉴 공통 컴포넌트 구현
BottomMenu 컴포넌트는 다음과 같은 prop을 받습니다.

```
  menuItems: { label: string; action: () => void }[];
  onlyCancel?: boolean;
```

#### 1️⃣ menuItems
label과 해당 메뉴를 클릭했을 때 실행할 함수인 action을 포함한 배열을 prop으로 받게 했습니다.
아래와 같이 메뉴 항목들을 정의하고 이 배열을 BottomMenu에 넘기면 됩니다.
```
  const menuItems = [
    { label: '취소', action: () => console.log('취소 버튼 클릭') },
    { label: '삭제', action: () => console.log('삭제 버튼 클릭') },
    { label: '플리로', action: () => console.log('플리로 버튼 클릭') },
    { label: '보관', action: () => console.log('보관 버튼 클릭') },
  ];
```
항목에 따라 텍스트와 실행할 함수가 달라지기 때문에 배열로 받는 게 적합하겠다 생각했는데 혹시 다른 좋은 방법이 있다면 알려주세요 🥺

#### 2️⃣ onlyCancel (optional)
<img width="411" alt="image" src="https://github.com/user-attachments/assets/6d007610-5728-44ad-a0ea-612e773fd86b" />

'취소'라는 텍스트가 기본적으로 회색인데, '취소' 항목만 단독으로 있는 경우에는 이를 브랜드 컬러로 지정을 해줘야 해서 onlyCancel prop을 추가했습니다.

<br/>

## 📸 Screenshot (optional) 
<!-- 필요 시 관련 스크린샷을 첨부해주세요. -->
<img width="383" alt="image" src="https://github.com/user-attachments/assets/bb4db89f-b755-4632-b967-76a8c13649a8" />

<br/>

## 🧙‍♂️ To Reviewer
<!-- 리뷰어가 집중해주면 좋을 부분/참고한 레퍼런스/논의할 부분이 있다면 작성해주세요. -->
원래 이 컴포넌트가 아래에서 위로 올라오는 팝업 형태인데요,, 아무리 스타일을 수정해도 바텀 네비바 위에 겹쳐져서 띄워지지 않더라고요.
(제 예상으로는 스크린 높이가 바텀 네비게이션 바를 제외한 값으로 설정되어 있어서 화면에 제대로 보이지 않는 것 같습니다.)
그래서 아래 코드를 작성해 하단 메뉴 컴포넌트가 띄워졌을 때 바텀 네비바가 보이지 않도록 설정했습니다.
하지만, 그렇게 하다보니 네비게이션 바가 사라지고 난 후 하단 메뉴가 올라오는 어색한 팝업 형태가 되어버려서 일단 애니메이션 코드는 지워놓은 상태입니다. 그렇지만 계속 붙잡고 있을 상황이 아니라고 판단해 추후에 다시 도전하는 걸로 하겠습니다 😥

```
  useEffect(() => {
    navigation.setOptions({ tabBarStyle: { display: 'none' } });
    return () => navigation.setOptions({ tabBarStyle: styles.tabBar });
  }, [navigation]);
```

<br/>
