### PR TITLE
[Feat/#31] 하단 모달 구현

### DIFF
--- a/components/common/BottomModal.tsx
+++ b/components/common/BottomModal.tsx
@@ -90,23 +90,28 @@ const BottomModal = ({
           </View>
 
           {/* 컨텐츠 */}
-          <View className="bg-white w-full pb-[27px]">
+          <View className="bg-primaryBg w-full pb-[27px]">
             {options?.length > 0 &&
-              options.map((option) => (
-                <TouchableOpacity
-                  key={option.id}
-                  onPress={option.action}
-                  className="flex-row bg-white h-14 justify-center items-center border-b-[1px] border-borderBg gap-2"
-                >
-                  {hasCheckBox && <IcSelectOff width={18} height={18} />}
-                  <Typo
-                    variant="text-16_M"
-                    className={option.text === '삭제' ? 'text-brand' : 'text-black'}
+              options.map((option, index) => {
+                const isLast = index === options.length - 1;
+                return (
+                  <TouchableOpacity
+                    key={option.id}
+                    onPress={option.action}
+                    className={`flex-row bg-primaryBg h-14 justify-center items-center gap-2 ${
+                      isLast ? '' : 'border-b-[1px] border-borderBg'
+                    }`}
                   >
-                    {option.text}
-                  </Typo>
-                </TouchableOpacity>
-              ))}
+                    {hasCheckBox && <IcSelectOff width={18} height={18} />}
+                    <Typo
+                      variant="text-16_M"
+                      className={option.text === '삭제' ? 'text-brand' : 'text-black'}
+                    >
+                      {option.text}
+                    </Typo>
+                  </TouchableOpacity>
+                );
+              })}
             {children}
           </View>
         </Animated.View>

--- a/components/common/BottomModal.tsx
+++ b/components/common/BottomModal.tsx
@@ -1,31 +1,118 @@
-import { Text, View } from 'react-native';
-import { forwardRef, useCallback, useMemo } from 'react';
-import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import React, { useRef, useMemo, useEffect } from 'react';
+import { Modal, View, TouchableOpacity, Animated, PanResponder } from 'react-native';
+import Typo from './Typo';
+import { IcSelectOff } from 'assets/svgs';
 
-const BottomModal = forwardRef<BottomSheetModal>((_, ref) => {
-  const snapPoints = useMemo(() => ['25%', '50%'], []);
+interface BottomModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  options?: { id: number; text: string; action: () => void }[];
+  hasCheckBox?: boolean;
+  children?: React.ReactNode;
+}
 
-  const handleSheetChanges = useCallback((index: number) => {
-    console.log('handleSheetChanges', index);
-  }, []);
+const DRAG_THRESHOLD = 50;
 
-  console.log(ref);
+const BottomModal = ({
+  isOpen,
+  onClose,
+  options = [],
+  hasCheckBox,
+  children,
+}: BottomModalProps) => {
+  const translateY = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (isOpen) {
+      // 하단 모달이 열릴 때 아래에서 올라오는 애니메이션
+      translateY.setValue(300);
+      Animated.timing(translateY, {
+        toValue: 0,
+        useNativeDriver: true,
+      }).start();
+    } else {
+      // 닫힐 때 translateY를 0으로 초기화
+      translateY.setValue(0);
+    }
+  }, [isOpen, translateY]);
+
+  // 헤더를 슬라이드하여 하단 모달을 닫기 위한 PanResponder 설정
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onPanResponderMove: (_, gestureState) => {
+          // 아래로만 끌어내릴 때 translateY 업데이트
+          if (gestureState.dy > 0) {
+            translateY.setValue(gestureState.dy);
+          }
+        },
+        onPanResponderRelease: (_, gestureState) => {
+          if (gestureState.dy > DRAG_THRESHOLD) {
+            // threshold 이상 끌어내리면 모달 닫기
+            onClose();
+          } else {
+            // threshold 이하이면 제자리로
+            Animated.spring(translateY, {
+              toValue: 0,
+              useNativeDriver: true,
+            }).start();
+          }
+        },
+      }),
+    [onClose, translateY]
+  );
 
   return (
-    <BottomSheetModal
-      ref={ref}
-      index={1}
-      snapPoints={snapPoints}
-      backgroundStyle={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
-      onChange={handleSheetChanges}
-    >
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text>바텀 모달</Text>
-      </View>
-    </BottomSheetModal>
-  );
-});
+    <Modal transparent animationType="none" visible={isOpen} onRequestClose={onClose}>
+      <View className="flex-1">
+        {/* 딤드 */}
+        <TouchableOpacity
+          onPress={onClose}
+          activeOpacity={1}
+          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' }}
+        />
+        <Animated.View
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            transform: [{ translateY }],
+          }}
+        >
+          {/* 헤더 */}
+          <View
+            {...panResponder.panHandlers}
+            className="items-center justify-center bg-primaryBg pt-2 border-t-[1px] border-black"
+          >
+            <View className="w-10 h-1 bg-nonActiveGrey rounded-[2px]" />
+          </View>
 
-BottomModal.displayName = 'BottomModal';
+          {/* 컨텐츠 */}
+          <View className="bg-white w-full pb-[27px]">
+            {options?.length > 0 &&
+              options.map((option) => (
+                <TouchableOpacity
+                  key={option.id}
+                  onPress={option.action}
+                  className="flex-row bg-white h-14 justify-center items-center border-b-[1px] border-borderBg gap-2"
+                >
+                  {hasCheckBox && <IcSelectOff width={18} height={18} />}
+                  <Typo
+                    variant="text-16_M"
+                    className={option.text === '삭제' ? 'text-brand' : 'text-black'}
+                  >
+                    {option.text}
+                  </Typo>
+                </TouchableOpacity>
+              ))}
+            {children}
+          </View>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+};
 
 export default BottomModal;

--- a/components/common/index.ts
+++ b/components/common/index.ts
@@ -16,6 +16,7 @@ import EmotionDetailTags from './Tags/EmotionDetailTags';
 import EmotionModal from './Tags/EmotionModal';
 import FilterTags from './Tags/FilterTags';
 import TagSection from './Tags/TagSection';
+import BottomModal from './BottomModal';
 
 export {
   BottomMenu,
@@ -36,4 +37,5 @@ export {
   EmotionModal,
   FilterTags,
   TagSection,
+  BottomModal,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@expo/metro-runtime": "~4.0.1",
         "@expo/ngrok": "^4.1.0",
         "@expo/vector-icons": "^14.0.2",
-        "@gorhom/bottom-sheet": "^5",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
         "expo": "~52.0.23",
@@ -3328,45 +3327,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@gorhom/bottom-sheet": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.1.1.tgz",
-      "integrity": "sha512-Y8FiuRmeZYaP+ZGQ0axDwWrrKqVp4ByYRs1D2fTJTxHMt081MHHRQsqmZ3SK7AFp3cSID+vTqnD8w/KAASpy+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@gorhom/portal": "1.0.14",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-native": "*",
-        "react": "*",
-        "react-native": "*",
-        "react-native-gesture-handler": ">=2.16.1",
-        "react-native-reanimated": ">=3.16.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@gorhom/portal": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
-      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.1"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@expo/metro-runtime": "~4.0.1",
     "@expo/ngrok": "^4.1.0",
     "@expo/vector-icons": "^14.0.2",
-    "@gorhom/bottom-sheet": "^5",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "expo": "~52.0.23",


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#이슈번호] 기능 추가 및 변경" 와 같이 작성해주세요! -->

## 📌 Related Issue

- Closes #31 


## 🗝️ Key Changes
<!-- 작업 내용에 대한 설명/이슈사항을 작성해주세요. -->
### BottomModal.tsx
하단 모달의 헤더부분을 아래로 슬라이드하거나, 딤드 된 배경을 터치하면 모달이 닫힙니다. (Screenshot에 첨부한 영상 참고)

![image](https://github.com/user-attachments/assets/15370de2-ead8-4713-bce5-6d28de3876e8)
바텀 모달에 넘겨주는 인자는 기본적으로 `isOpen`, `onClose` 입니다. (BaseModal과 동일)
모달 열림을 관리하는 상태와 핸들러를 사진의 예시와 같이 정의하여 넘겨줄 수 있습니다.
<br/>

|![image](https://github.com/user-attachments/assets/67c578a2-9d1c-41d8-8aa8-67127827e7f6)|![image](https://github.com/user-attachments/assets/32d96bf6-4f26-485a-a2aa-dcee3806c2f6)|
|------|------|

위와 같이 옵션만 있는 하단 모달의 경우 예시 사진처럼 options를 배열로 정의하여 `options` prop으로 넘겨주면 됩니다. 이때 오른쪽처럼 체크박스가 있다면 `hasCheckBox={true}`로 넘겨줍니다 (false는 아예 안 써도 됩니다)
<br/>

|![image](https://github.com/user-attachments/assets/9dd4a8d2-1e54-47db-9a50-dd0fa9cb1107)|![image](https://github.com/user-attachments/assets/ee6a5a1b-436c-4951-9cec-f53e8246e2d2)|
|------|------|

위와 같이 커스텀된 하단 모달은 `<BottomModal></BottomModal>` 로 감싼 children을 넘겨주면 됩니다.

<br/>

## 📸 Screenshot (optional) 
<!-- 필요 시 관련 스크린샷을 첨부해주세요. -->
https://github.com/user-attachments/assets/422e737d-babc-4eb4-9965-0626a2ae67c9

<br/>


## 🧙‍♂️ To Reviewer
<!-- 리뷰어가 집중해주면 좋을 부분/참고한 레퍼런스/논의할 부분이 있다면 작성해주세요. -->
children으로 넘겨지는 내용물은 페이지마다 재사용되는 컴포넌트를 쓰거나 각기 다를 것 같아 BottomModal을 틀로 사용하시면 될 것 같습니다. 그 외에 혹시 제가 빠트린 부분이 있다면 말씀해주세요! 🙇‍♀️
<br/>
